### PR TITLE
[fix] TableEditor : Reset row order on edit.

### DIFF
--- a/core/src/main/java/fr/putnami/pwt/core/widget/client/TableEditorBody.java
+++ b/core/src/main/java/fr/putnami/pwt/core/widget/client/TableEditorBody.java
@@ -136,10 +136,18 @@ public class TableEditorBody<T> extends TableBody<T>
 
 	@Override
 	public void edit(Collection<T> value) {
-		for (TableRow<T> row : this.getRowList()) {
-			row.setVisible(false);
-		}
+		resetRows();
 		getDriverOrThrow().edit(value);
+	}
+
+	private void resetRows() {
+		Collections.sort(this.getRowList());
+		List<TableRow<T>> rows = this.getRowList();
+		int i = 0;
+		for (TableRow<T> row : rows) {
+			row.setVisible(false);
+			insert(row, ++i, true);
+		}
 	}
 
 	@Override
@@ -188,9 +196,6 @@ public class TableEditorBody<T> extends TableBody<T>
 			rows.remove(secondIndex);
 			rows.add(secondIndex, first);
 
-			first.setIndex(secondIndex);
-			second.setIndex(firstIndex);
-
 			if (values != null) {
 				values.remove(firstIndex);
 				values.add(firstIndex, secondVal);
@@ -204,9 +209,6 @@ public class TableEditorBody<T> extends TableBody<T>
 			rows.add(secondIndex, first);
 			rows.remove(firstIndex);
 			rows.add(firstIndex, second);
-
-			first.setIndex(secondIndex);
-			second.setIndex(firstIndex);
 
 			if (values != null) {
 				values.remove(secondIndex);

--- a/core/src/main/java/fr/putnami/pwt/core/widget/client/TableRow.java
+++ b/core/src/main/java/fr/putnami/pwt/core/widget/client/TableRow.java
@@ -42,7 +42,7 @@ import fr.putnami.pwt.core.widget.client.base.AbstractPanel;
 import fr.putnami.pwt.core.widget.client.base.AbstractTableCell;
 
 public class TableRow<T> extends AbstractPanel
-	implements EditorOutput<T>, EditorInput<T>, EditorLeaf, EditorModel<T>, HasReadonly, HasClickHandlers {
+	implements EditorOutput<T>, EditorInput<T>, EditorLeaf, EditorModel<T>, HasReadonly, HasClickHandlers, Comparable<TableRow<T>> {
 
 	private MessageHelper messageHelper;
 	private Model<T> model;
@@ -160,4 +160,8 @@ public class TableRow<T> extends AbstractPanel
 		return this.driver;
 	}
 
+	@Override
+	public int compareTo(TableRow<T> o) {
+		return Integer.compare(index, o.index);
+	}
 }


### PR DESCRIPTION
In TableEditor, row order are not reset when editing new values. 