### PR TITLE
[fix] Do not set Image src if value is null

### DIFF
--- a/core/src/main/java/fr/putnami/pwt/core/widget/client/Image.java
+++ b/core/src/main/java/fr/putnami/pwt/core/widget/client/Image.java
@@ -91,10 +91,12 @@ public class Image extends AbstractWidget implements EditorOutput<String> {
 
 	public void setSrc(String src) {
 		this.src = src;
-		if (this.src != null && this.src.startsWith("/")) {
-			this.src = GWT.getModuleName() + this.src;
+		if (this.src != null) {
+			if (this.src.startsWith("/")) {
+				this.src = GWT.getModuleName() + this.src;
+			}
+			this.imgElement.setSrc(this.src);
 		}
-		this.imgElement.setSrc(this.src);
 	}
 
 	public String getAlt() {


### PR DESCRIPTION
Do not set Image src if value is null, beacause it causes an http request with a "/null" path.