### PR TITLE
[fix] Clone path on AbstractWidget cloning

### DIFF
--- a/core/src/main/java/fr/putnami/pwt/core/widget/client/base/AbstractWidget.java
+++ b/core/src/main/java/fr/putnami/pwt/core/widget/client/base/AbstractWidget.java
@@ -39,6 +39,7 @@ public abstract class AbstractWidget extends Widget implements HasResponsiveVisi
 
 	public AbstractWidget(AbstractWidget source) {
 		this(source.tagName);
+        this.path = source.path;
 		this.handlerManager = new HandlerManager(source.handlerManager, this);
 		this.handlerManager.resetSinkEvents();
 		StyleUtils.cloneStyle(this, source);


### PR DESCRIPTION
When AbstractWidget (like OutputText) are cloned, the path is not cloned.