### PR TITLE
[fix] Use setters on AbstractTextOutput cloning

### DIFF
--- a/core/src/main/java/fr/putnami/pwt/core/widget/client/base/AbstractTextOutput.java
+++ b/core/src/main/java/fr/putnami/pwt/core/widget/client/base/AbstractTextOutput.java
@@ -56,9 +56,9 @@ public abstract class AbstractTextOutput<T> extends AbstractOutput<T> implements
 
 	protected AbstractTextOutput(AbstractTextOutput<T> source) {
 		super(source);
-		this.renderer = source.renderer;
-		this.style = source.style;
-		this.text = source.text;
+        setText(source.text);
+        setRenderer(source.renderer);
+        setStyle(source.style);
 	}
 
 	@Override


### PR DESCRIPTION
Use setter on AbstractTextOutput cloning constructor, because the element is already created, so it can be updated 