### PR TITLE
[fix] Set parent context for sub context created for collections

### DIFF
--- a/core/src/main/java/fr/putnami/pwt/core/model/client/visitor/BinderVisitor.java
+++ b/core/src/main/java/fr/putnami/pwt/core/model/client/visitor/BinderVisitor.java
@@ -84,7 +84,7 @@ public class BinderVisitor extends AbstractVisitor {
 				EditorValue traversalEditor = editorList.getEditorForTraversal(i);
 				Context<EditorValue> contextCreated = (Context<EditorValue>) this.driver.getContext(traversalEditor);
 				if (contextCreated == null) {
-					contextCreated = ContextFactory.Util.get().createContext(this.driver, null, traversalEditor);
+					contextCreated = ContextFactory.Util.get().createContext(this.driver, context, traversalEditor);
 					if (editor instanceof HasReadonly) {
 						this.driver.accept(new ReadonlyVisitor(editor, ((HasReadonly) editor).getReadonly(), true), contextCreated);
 					}


### PR DESCRIPTION
Avoid multiple context added to driver (today, the TableEditorTd contexts are added to the TableEditor driver which is a bug beacause the TableRw is a Leaf editor so its children mus not be "visible" to its parent driver)