### PR TITLE
[feature] Add target to Anchor and set anchor href on edit

### DIFF
--- a/core/src/main/java/fr/putnami/pwt/core/widget/client/Anchor.java
+++ b/core/src/main/java/fr/putnami/pwt/core/widget/client/Anchor.java
@@ -98,6 +98,7 @@ public class Anchor<T> extends AbstractPanel
 
 	private T value;
 	private String link;
+    private String target;
 
 	public Anchor() {
 		super(AnchorElement.TAG);
@@ -112,6 +113,10 @@ public class Anchor<T> extends AbstractPanel
 	public Anchor(Anchor<T> source) {
 		super(source);
 		this.endConstruct();
+        if (source.link != null) {
+            this.setLink(source.link);
+        }
+        this.setTarget(source.target);
 		this.cloneSourceWidgets(source);
 	}
 
@@ -142,7 +147,20 @@ public class Anchor<T> extends AbstractPanel
 		}
 	}
 
-	public void setLinkAsDummy() {
+    public String getTarget() {
+        return target;
+    }
+
+    public void setTarget(String target) {
+        this.target = target;
+        if (target == null) {
+            this.getElement().removeAttribute("target");
+        } else {
+            AnchorElement.as(this.getElement()).setTarget(target);
+        }
+    }
+
+    public void setLinkAsDummy() {
 		AnchorElement.as(this.getElement()).setHref(AnchorUtils.DUMMY_HREF);
 	}
 
@@ -154,6 +172,13 @@ public class Anchor<T> extends AbstractPanel
 	@Override
 	public void edit(T value) {
 		this.value = value;
+        if (this.link == null) {
+            if (this.value instanceof String) {
+                AnchorElement.as(this.getElement()).setHref((String) this.value);
+            } else {
+                setLinkAsDummy();
+            }
+        }
 	}
 
 	@Override

--- a/core/src/main/java/fr/putnami/pwt/core/widget/client/InputList.java
+++ b/core/src/main/java/fr/putnami/pwt/core/widget/client/InputList.java
@@ -64,6 +64,7 @@ import fr.putnami.pwt.core.theme.client.IconFont;
 import fr.putnami.pwt.core.widget.client.base.SimpleStyle;
 import fr.putnami.pwt.core.widget.client.event.ButtonEvent;
 import fr.putnami.pwt.core.widget.client.event.ButtonEvent.Handler;
+import fr.putnami.pwt.core.widget.client.util.AnchorUtils;
 import fr.putnami.pwt.core.widget.client.util.StyleUtils;
 
 public class InputList<T> extends List
@@ -125,6 +126,7 @@ public class InputList<T> extends List
 			StyleUtils.addStyle(this.deleteButton, InputList.STYLE_CLOSE);
 			StyleUtils.addStyle(this.clear, InputList.STYLE_CLEAR);
 			this.deleteButton.setTabIndex(-1);
+			this.deleteButton.setLink(AnchorUtils.DUMMY_HREF);
 			this.deleteButton.addClickHandler(new ClickHandler() {
 				@Override
 				public void onClick(ClickEvent event) {


### PR DESCRIPTION
Its an idea, but I want to edit a value directly as an anchor href value, so if the value edited in an anchor is a String an no specific link has been setted the anchor href value is setted with the edited value. 